### PR TITLE
Update map tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,8 @@
     iconUrl: 'images/icon3.png',
 
     iconSize:     [12, 43.5], // size of the icon
-    iconAnchor:   [6, 43.5], // point of the icon which will correspond to marker's location
-    popupAnchor:  [0, -43.5] // point from which the popup should open relative to the iconAnchor
+    iconAnchor:   [6, 43.5],  // point of the icon which will correspond to marker's location
+    popupAnchor:  [0, -43.5]  // point from which the popup should open relative to the iconAnchor
   });
 
   var beerCanIcon = L.icon({
@@ -38,10 +38,33 @@
 
   var defaultIcon = beerBottleIcon;
 
-  L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/toner/{z}/{x}/{y}.png ',
-              {attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'}).addTo(map);
+  // Expired: 2023-10-31
+  // L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/toner/{z}/{x}/{y}.png ',
+  //             {attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'}).addTo(map);
+
+  // List of CartoDB maps: rastertiles/voyager, rastertiles/voyager_nolabels, rastertiles/voyager_only_labels, rastertiles/voyager_labels_under, 
+  // rastertiles/voyager_no_buildings, rastertiles/voyager_only_labels_no_buildings, rastertiles/voyager_no_labels_no_buildings, light_all, 
+  // light_nolabels, light_only_labels, dark_all, dark_nolabels, dark_only_labels, spotify_dark
+
+  // Areas feature black water and gray land, while labels are displayed in white for countries and capitals and in black for regions.
+  L.tileLayer('https://{s}.basemaps.cartocdn.com/spotify_dark/{z}/{x}/{y}{r}.png', {
+      attribution: '&copy; <a href="https://carto.com/attributions">CartoDB</a>'
+  }).addTo(map);
+
+  // Dark 2nd choice
+  // L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+  //     attribution: '&copy; <a href="https://carto.com/attributions">CartoDB</a>'
+  // }).addTo(map);
+
+
+  // Original OSM
   // L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png',
   //            {attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'}).addTo(map);
+
+  // Topographic
+  //   L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+  //     attribution: '&copy; <a href="https://opentopomap.org">OpenTopoMap</a> contributors'
+  // }).addTo(map);
 
 
   for (var i = 0; i < markers.length; ++i) {


### PR DESCRIPTION
This pull request updates the map tiles to ensure the map remains active, following the expiration of the previous tiles from stamen.com

Selected the **Spotify Dark** map tiles from CartoDB, which feature black water, gray land, and distinct label styles similar to the previously used tile. This choice ensures both a consistent map appearance and keeps the map up-to-date.

Here's a list of other available options for reference:

- rastertiles/voyager
- rastertiles/voyager_nolabels
- rastertiles/voyager_only_labels
- rastertiles/voyager_labels_under
- rastertiles/voyager_no_buildings
- rastertiles/voyager_only_labels_no_buildings
- rastertiles/voyager_no_labels_no_buildings
- light_all
- light_nolabels
- light_only_labels
- dark_all
- dark_nolabels
- dark_only_labels
- spotify_dark